### PR TITLE
Add Changelog Entry to DoD

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 - [ ] Unit- / BDD-Tests sind erstellt _(Frage lautet immer: Warum braucht es keine Unit-/BDD-Tests)_.
 - [ ] Keine Todo’s im Code _(nur mit Begründung)_.
 - [ ] ReSharper Kriterien sind alle grün _(mind. bei neuen Klassen, wenn möglich auch bei geänderten)_.
+- [ ] Changelog Eintrag geschrieben _(bei Major oder Minor bump)_.
 
 __Reminder__
 - [ ] Dokumentation ist aktualisiert _(Updatealeitung, Wiki, Readme.md, Installation.md)_.


### PR DESCRIPTION
Wie am DevOps Meeting besprochen sollten wir das schreiben des ChangeLogs in die DoD aufnehmen. 

## Todo
- [ ] überlegen ob wir einen link auf https://keepachangelog.com/de/1.0.0/ in die DoD einfügen sollten, Die Infos dort mal gehört zu haben schadet keinem Entwickler IMHO
- [ ] Evtl write-access für mich? 